### PR TITLE
Fix missing hours in time distribution charts

### DIFF
--- a/src/plotly_visualizations.py
+++ b/src/plotly_visualizations.py
@@ -102,7 +102,28 @@ class InteractiveStravaVisualizer:
 
     def create_time_distribution_chart(self):
         """Create an interactive polar chart of activity times with filters"""
-        hourly_counts = self.df['hour'].value_counts().sort_index()
+        hourly_counts = (
+            self.df['hour']
+            .value_counts()
+            .reindex(range(24), fill_value=0)
+            .sort_index()
+        )
+
+        weekday_counts = (
+            self.df[self.df['day_of_week'].isin(
+                ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
+            )]['hour']
+            .value_counts()
+            .reindex(range(24), fill_value=0)
+            .sort_index()
+        )
+
+        weekend_counts = (
+            self.df[self.df['day_of_week'].isin(['Saturday', 'Sunday'])]['hour']
+            .value_counts()
+            .reindex(range(24), fill_value=0)
+            .sort_index()
+        )
         
         fig = go.Figure()
         
@@ -146,19 +167,17 @@ class InteractiveStravaVisualizer:
                         dict(
                             label="All Days",
                             method="update",
-                            args=[{"visible": [True]}]
+                            args=[{"r": [hourly_counts.values]}]
                         ),
                         dict(
                             label="Weekdays",
                             method="update",
-                            args=[{"visible": [True]}],
-                            args2=[{"r": [self.df[self.df['day_of_week'].isin(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'])]['hour'].value_counts().sort_index().values]}]
+                            args=[{"r": [weekday_counts.values]}]
                         ),
                         dict(
                             label="Weekends",
                             method="update",
-                            args=[{"visible": [True]}],
-                            args2=[{"r": [self.df[self.df['day_of_week'].isin(['Saturday', 'Sunday'])]['hour'].value_counts().sort_index().values]}]
+                            args=[{"r": [weekend_counts.values]}]
                         )
                     ]),
                 )

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -84,11 +84,16 @@ class StravaVisualizer:
         # Create 24-hour clock
         hours = np.linspace(0, 2*np.pi, 24, endpoint=False)
         
-        # Count activities by hour
-        activity_counts = self.df['hour'].value_counts().sort_index()
-        
+        # Count activities by hour ensuring all 24 hours are represented
+        activity_counts = (
+            self.df['hour']
+            .value_counts()
+            .reindex(range(24), fill_value=0)
+            .sort_index()
+        )
+
         # Create bars
-        bars = ax.bar(hours, activity_counts, width=2*np.pi/24, alpha=0.7)
+        bars = ax.bar(hours, activity_counts.values, width=2*np.pi/24, alpha=0.7)
         
         # Customize the plot
         ax.set_theta_zero_location('N')


### PR DESCRIPTION
## Summary
- ensure 24 hour buckets are always present when plotting hourly counts
- update plotly interactive chart to use these counts and fix button updates

## Testing
- `python -m py_compile $(ls src/*.py)`

------
https://chatgpt.com/codex/tasks/task_e_683f3fee86fc8321ad1d3899a3ac550b