### PR TITLE
Fix newline at end of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ python src/visualization.py
   - `data_collection.py`: Fetches and stores Strava activity data
   - `visualization.py`: Generates visualizations from the collected data
 - `data/`: Directory for storing activity data
-- `output/`: Directory for generated visualizations 
+- `output/`: Directory for generated visualizations


### PR DESCRIPTION
## Summary
- ensure README ends with a newline

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f431fec788321a6012f812078b215