### PR TITLE
Update cron comment

### DIFF
--- a/.github/workflows/strava-weekly-update.yml
+++ b/.github/workflows/strava-weekly-update.yml
@@ -2,7 +2,7 @@ name: Weekly Strava Data Update
 
 on:
   schedule:
-    # Run at midnight PST on Thursday (8 AM UTC Friday)
+    # Run at midnight PST on Friday (8 AM UTC Friday)
     - cron: '0 8 * * 5'
   workflow_dispatch:
     # Allow manual triggering


### PR DESCRIPTION
## Summary
- fix weekday description in weekly cron comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f432df8a88321a9b079193b26b8d6