### PR TITLE
Add format_time unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,12 @@ python src/visualization.py
   - `data_collection.py`: Fetches and stores Strava activity data
   - `visualization.py`: Generates visualizations from the collected data
 - `data/`: Directory for storing activity data
-- `output/`: Directory for generated visualizations 
+- `output/`: Directory for generated visualizations
+
+## Running Tests
+
+Execute the project's unit tests using [pytest](https://pytest.org/):
+
+```bash
+pytest
+```

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+# Ensure src directory is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+# Provide minimal stub modules for dependencies not installed in the test env
+sys.modules.setdefault('pytz', SimpleNamespace(timezone=lambda tz: None,
+                                              utc=SimpleNamespace(localize=lambda dt: dt)))
+sys.modules.setdefault('dotenv', SimpleNamespace(load_dotenv=lambda *args, **kwargs: None))

--- a/tests/test_commute_analyzer.py
+++ b/tests/test_commute_analyzer.py
@@ -1,0 +1,34 @@
+from commute_analyzer import CommuteAnalyzer
+
+
+def _make_analyzer():
+    """Create an instance of CommuteAnalyzer without running __init__."""
+    return CommuteAnalyzer.__new__(CommuteAnalyzer)
+
+
+def test_format_time_seconds_only():
+    ca = _make_analyzer()
+    assert ca._format_time(0.5) == "30s"
+
+
+def test_format_time_minutes_only():
+    ca = _make_analyzer()
+    assert ca._format_time(5) == "5m"
+
+
+def test_format_time_hours_with_minutes():
+    ca = _make_analyzer()
+    assert ca._format_time(130) == "2h 10m"
+
+
+def test_format_time_days_case():
+    ca = _make_analyzer()
+    # 1 day 12 hours = 2160 minutes
+    assert ca._format_time(2160) == "1d 12h"
+
+
+def test_format_time_years_case():
+    ca = _make_analyzer()
+    # 1 year 2 days = 365 days + 2 days
+    minutes = (365 + 2) * 24 * 60
+    assert ca._format_time(minutes) == "1y 2d"


### PR DESCRIPTION
## Summary
- add pytest helper to load `src` and stub missing dependencies
- test `_format_time` for minutes, seconds, hours, days and years

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f43300b6c8321bd2a1f16f2b61ca7